### PR TITLE
Feat/global cnn explainability max activations

### DIFF
--- a/readml/explainers/dl/max_activations.py
+++ b/readml/explainers/dl/max_activations.py
@@ -164,7 +164,7 @@ class MaxActivation:
                 )
         return overall_max_activations
 
-    def get_filter_max_activations(
+    def get_filter_max_activations_from_image_dataset(
         self, img_dataset: Iterable, nb_images_per_filter: int = 9
     ) -> dict:
         """Given a dataset of image batches and a number of images parts to keep per
@@ -315,7 +315,7 @@ class MaxActivation:
                     )
         return x_min, x_max, y_min, y_max
 
-    def get_filter_max_activations_visualization(
+    def get_filter_max_activations_from_image_dataset_visualization(
         self, max_activations: dict, **kwargs
     ) -> List[List[io.BytesIO]]:
         """For all the filters of the CNN, create BytesIO containing nb_images_per_filter
@@ -394,9 +394,13 @@ if __name__ == "__main__":
 
     # test
     max_activation = MaxActivation(model)
-    filter_max_activations = max_activation.get_filter_max_activations(img_dataset)
-    all_layer_io = max_activation.get_filter_max_activations_visualization(
-        filter_max_activations, cmap="gray"
+    filter_max_activations = (
+        max_activation.get_filter_max_activations_from_image_dataset(img_dataset)
+    )
+    all_layer_io = (
+        max_activation.get_filter_max_activations_from_image_dataset_visualization(
+            filter_max_activations, cmap="gray"
+        )
     )
     desired_io = all_layer_io[3][0]
     desired_io.seek(0)

--- a/readml/explainers/dl/max_activations.py
+++ b/readml/explainers/dl/max_activations.py
@@ -466,8 +466,22 @@ class MaxActivation:
 
         # get maximum size to look at during optimization
         if nb_activation_to_max == "single":
+            feature_map_x = 0
+            feature_map_y = 0
             x_min, x_max, y_min, y_max = self._feature_map_loc_to_input_loc(
-                self.model, layer_name, 0, 0
+                self.model, layer_name, feature_map_x, feature_map_y
+            )
+            if min(x_min, y_min) < 0:
+                feature_map_x -= x_min
+                feature_map_y -= y_min
+                x_min, x_max, y_min, y_max = self._feature_map_loc_to_input_loc(
+                    self.model, layer_name, feature_map_x, feature_map_y
+                )
+            assert (
+                x_min >= 0
+                and y_min >= 0
+                and x_max < submodel.inputs[0].shape[1]
+                and y_max < submodel.inputs[0].shape[2]
             )
         elif nb_activation_to_max == "all":
             x_min, y_min = 0, 0

--- a/readml/explainers/dl/max_activations.py
+++ b/readml/explainers/dl/max_activations.py
@@ -496,7 +496,9 @@ class MaxActivation:
             with tf.GradientTape() as tape:
                 output = submodel(input_data)[0]
                 if nb_activation_to_max == "single":
-                    mean_activation = tf.reduce_mean(output[:, 0, 0, channel_id])
+                    mean_activation = tf.reduce_mean(
+                        output[:, feature_map_x, feature_map_y, channel_id]
+                    )
                 elif nb_activation_to_max == "all":
                     mean_activation = tf.reduce_mean(output[:, :, :, channel_id])
                 mean_activation_history.append(mean_activation)

--- a/readml/explainers/dl/max_activations.py
+++ b/readml/explainers/dl/max_activations.py
@@ -32,12 +32,22 @@ class MaxActivation:
         Raises
         ------
         TypeError
-            Raise an error is the provided model is not a tensorflow Model instance.
+            Raise an error if the provided model is not a tensorflow Model instance.
+
+        TypeError
+            Raise an error if the provided model input has more than a single input
+            corresponding to a single image.
         """
         if not isinstance(self.model, Model):
             raise TypeError(
                 "The provided model must be a tensorflow Model instance. "
                 "This is the only model which is currently supported."
+            )
+
+        if isinstance(self.model.inputs, list) and len(self.model.inputs) > 1:
+            raise ValueError(
+                "The provided model must have a single input "
+                "corresponding to the input image. "
             )
 
     def _get_conv2d_layers(self) -> List[Tuple[str, tf.Tensor]]:

--- a/readml/explainers/dl/max_activations.py
+++ b/readml/explainers/dl/max_activations.py
@@ -1,0 +1,404 @@
+import io
+from collections.abc import Iterable
+from itertools import tee
+from typing import List, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.models import Model
+
+
+class MaxActivation:
+    def __init__(self, model: Model):
+        """Initialize the instance with the provided model.
+        Check the provided objects.
+
+        Parameters
+        ----------
+        model : Model
+            CNN model.
+        """
+        self.model = model
+        self._check_model()
+        self.conv2d_layers = self._get_conv2d_layers()
+        self.activations_model = self._create_activations_model_from_conv2d_layers(
+            self.conv2d_layers
+        )
+
+    def _check_model(self):
+        """Check the provided model.
+
+        Raises
+        ------
+        TypeError
+            Raise an error is the provided model is not a tensorflow Model instance.
+        """
+        if not isinstance(self.model, Model):
+            raise TypeError(
+                "The provided model must be a tensorflow Model instance. "
+                "This is the only model which is currently supported."
+            )
+
+    def _get_conv2d_layers(self) -> List[Tuple[str, tf.Tensor]]:
+        """Get all Conv2D layers of the model.
+
+        Returns
+        -------
+        List[Tuple[str, tf.Tensor]]
+            List of Conv2D layers with their name and the corresponding tensor.
+        """
+        conv2d_layers = [
+            (layer.name, layer.output)
+            for layer in self.model.layers
+            if isinstance(layer, tf.keras.layers.Conv2D)
+        ]
+        return conv2d_layers  # type: ignore
+
+    def _create_activations_model_from_conv2d_layers(
+        self, conv2d_layers: List[Tuple[str, tf.Tensor]]
+    ) -> Model:
+        """
+        Create a submodel, which outputs the activations of conv2D layers.
+        """
+        activations_model = Model(
+            self.model.inputs,
+            outputs=[conv2d_layer[1] for conv2d_layer in conv2d_layers],
+        )
+        return activations_model
+
+    def _initialize_output(self, activations_model: Model) -> dict:
+        """Initialize the output of the get_filter_max_activations method.
+
+        Parameters
+        ----------
+        activations_model : Model
+            Model that outputs the activations of all Conv2D layers.
+
+        Returns
+        -------
+        dict
+            Initialized output.
+        """
+        max_activations = {}
+        for layer_id in range(len(activations_model.output)):
+            max_activations[layer_id] = {}
+            for channel_id in range(activations_model.output[layer_id].shape[-1]):
+                max_activations[layer_id][channel_id] = {"activation": [], "input": []}
+        return max_activations
+
+    def _update_max_activations(
+        self,
+        activations_model: Model,
+        predictions: np.ndarray,
+        layer_name: str,
+        image_batch: np.ndarray,
+        overall_max_activations: dict,
+        batch_max_activations: dict,
+        layer_id: int,
+        channel_id: int,
+        nb_images_per_filter: int,
+    ) -> dict:
+        """Update the max_activations dictionnary so that the nb_images_per_filter
+        images with the highest activations are kept considering the current
+        overall_max_activations and the candidates batch_max_activations.
+
+        For every image of the batch, the following operations are performed:
+        - If the current batch_max_activations is full (its length equals to
+        nb_images_per_filter), if the candidate has a higher activation, then remove the
+        lowest activation of overall_max_activations.
+        - If the current batch_max_activations is not full (less than
+        nb_images_per_filter), add the activation of the considered batch image.
+        The activation is added. The corresponding part of the input image is computed
+        and added to overall_max_activations.
+        """
+        for batch_max_activation in batch_max_activations:
+            # if there are already nb_images_per_filter images in overall_max_activations
+            # but batch_max_activation is higher than the min of overall_max_activations
+            # then remove the min activation of overall_max_activations
+            if len(
+                overall_max_activations[layer_id][channel_id]["activation"]
+            ) == nb_images_per_filter and batch_max_activation.numpy() > min(
+                overall_max_activations[layer_id][channel_id]["activation"]
+            ):
+                index_to_remove = overall_max_activations[layer_id][channel_id][
+                    "activation"
+                ].index(
+                    min(overall_max_activations[layer_id][channel_id]["activation"])
+                )
+                del overall_max_activations[layer_id][channel_id]["activation"][
+                    index_to_remove
+                ]
+                del overall_max_activations[layer_id][channel_id]["input"][
+                    index_to_remove
+                ]
+
+            # if there are less than nb_images_per_filter in overall_max_activations
+            # then add batch_max_activation
+            if (
+                len(overall_max_activations[layer_id][channel_id]["activation"])
+                < nb_images_per_filter
+            ):
+                overall_max_activations[layer_id][channel_id]["activation"].append(
+                    batch_max_activation.numpy()
+                )
+                loc = tf.where(
+                    predictions[layer_id][:, :, :, channel_id] == batch_max_activation
+                )[
+                    0
+                ]  # take the first one if several
+                x_min, x_max, y_min, y_max = self._feature_map_loc_to_input_loc(
+                    activations_model,
+                    layer_name,
+                    loc[1].numpy(),
+                    loc[2].numpy(),
+                )
+                assert x_max - x_min == y_max - y_min
+                overall_max_activations[layer_id][channel_id]["input"].append(
+                    image_batch[
+                        loc[0].numpy(),
+                        x_min : x_max + 1,
+                        y_min : y_max + 1,
+                        :,
+                    ]
+                )
+        return overall_max_activations
+
+    def get_filter_max_activations(
+        self, img_dataset: Iterable, nb_images_per_filter: int = 9
+    ) -> dict:
+        """Given a dataset of image batches and a number of images parts to keep per
+        filter, retrieve the image parts that maximize the activations of all Conv2D
+        layers.
+
+        Parameters
+        ----------
+        img_dataset : Iterable
+            Dataset yielding batchs of images of shape (batch size, height, width, number of channels).
+        nb_images_per_filter: int, optional
+            Number of image parts (with the highest activations) to keep per filters,
+            by default 9.
+
+        Returns
+        -------
+        dict
+            _description_
+        """
+        self._check_dataset(img_dataset)
+        max_activations = self._initialize_output(self.activations_model)
+
+        # get max activations
+        for image_batch in img_dataset:
+            predictions = self.activations_model.predict(image_batch)
+            for layer_id in range(len(self.activations_model.output)):
+                layer_name = self.conv2d_layers[layer_id][0]
+                new_shape = np.prod(predictions[layer_id].shape[:3])
+                for channel_id in range(
+                    self.activations_model.output[layer_id].shape[-1]
+                ):
+                    batch_max_activations = tf.sort(
+                        tf.reshape(
+                            predictions[layer_id][:, :, :, channel_id], new_shape
+                        )
+                    )[-nb_images_per_filter:]
+                    max_activations = self._update_max_activations(
+                        self.activations_model,
+                        predictions,
+                        layer_name,
+                        image_batch,
+                        max_activations,
+                        batch_max_activations,
+                        layer_id,
+                        channel_id,
+                        nb_images_per_filter,
+                    )
+
+        return max_activations
+
+    @staticmethod
+    def _check_dataset(img_dataset):
+        """Check the provided dataset
+
+        Raises
+        ------
+        TypeError
+            Raise if the image dataset is not an iterable.
+        TypeError
+            Raise if the dataset images are not a numpy ndarray or a tensorflow Tensor.
+        TypeError
+            Raise if the shape of the dataset images is not as expected.
+        """
+        if not isinstance(img_dataset, Iterable):
+            raise TypeError(
+                "The image dataset must be an iterable, "
+                "for instance like a tensorflow Dataset."
+            )
+
+        _, img_dataset_iter_copy = tee(iter(img_dataset))
+        image_batch_example = next(img_dataset_iter_copy)
+        if not isinstance(image_batch_example, (tf.Tensor, np.ndarray)):
+            raise TypeError(
+                "Dataset images must be numpy arrays or a tensorflow tensors."
+            )
+
+        if not len(image_batch_example.shape) == 4:
+            raise TypeError(
+                "Dataset images must yield batchs of images, with shape "
+                "(batch size, height, width, number of channels). "
+                "Shape of the first element of the provided dataset is "
+                f"{image_batch_example.shape}."
+            )
+
+    def _locs_of_previous_layer(
+        self,
+        i: int,
+        j: int,
+        padding: str,
+        kernel_size: Tuple[int, int],
+        strides: Tuple[int, int],
+    ) -> Tuple[int, int, int, int]:
+        """Given the location of the activation of the current layer (i, j), the padding,
+        the kernel size and the stride of the current layer, get the corresponding
+        4 corners of the previous layer part that is used to compute the (i, j) value
+        of the current layer.
+        """
+        if padding == "valid":
+            shift = (0, 0)
+        elif padding == "same":
+            shift = tuple([-int(np.floor(x / 2)) for x in kernel_size])  # type: ignore
+        else:
+            raise ValueError(
+                "The expected value for padding are 'valid' and 'same'. "
+                f"The provided value {padding} is not handled."
+            )
+        return (
+            i * strides[0] + shift[0],
+            i * strides[0] + shift[0] + kernel_size[0] - 1,
+            j * strides[1] + shift[1],
+            j * strides[1] + shift[1] + kernel_size[1] - 1,
+        )
+
+    def _feature_map_loc_to_input_loc(
+        self, model: Model, layer_name: str, i: int, j: int
+    ) -> Tuple[int, int, int, int]:
+        """Get the indices of the input image corresponding to the activation located
+        at (i, j) in layer layer_name.
+        """
+        previous_layer = False
+        x_min = i
+        x_max = i
+        y_min = j
+        y_max = j
+        for layer in reversed(model.layers):
+            if layer.name == layer_name:
+                previous_layer = True
+            if previous_layer:
+                if isinstance(layer, tf.keras.layers.Conv2D):
+                    strides = layer.strides
+                    padding = layer.padding
+                    kernel_size = layer.kernel_size
+                    x_min, _, y_min, _ = self._locs_of_previous_layer(
+                        x_min, y_min, padding, kernel_size, strides
+                    )
+                    _, x_max, _, y_max = self._locs_of_previous_layer(
+                        x_max, y_max, padding, kernel_size, strides
+                    )
+                elif isinstance(layer, tf.keras.layers.MaxPooling2D):
+                    strides = layer.strides
+                    padding = layer.padding
+                    kernel_size = layer.pool_size
+                    x_min, _, y_min, _ = self._locs_of_previous_layer(
+                        x_min, y_min, padding, kernel_size, strides
+                    )
+                    _, x_max, _, y_max = self._locs_of_previous_layer(
+                        x_max, y_max, padding, kernel_size, strides
+                    )
+        return x_min, x_max, y_min, y_max
+
+    def get_filter_max_activations_visualization(
+        self, max_activations: dict, **kwargs
+    ) -> List[List[io.BytesIO]]:
+        """For all the filters of the CNN, create BytesIO containing nb_images_per_filter
+        of input image parts that maximize the activation of the filter.
+
+        Parameters
+        ----------
+        max_activations : dict
+            Results of get_filter_max_activations.
+        **kwargs:
+            kwargs for imshow, in particular for the color map.
+
+        Returns
+        -------
+        List[List[io.BytesIO]]
+            List of list of BytesIO.
+
+        The results may be saved as png with the following command:
+        desired_io = all_layer_io[3][0]
+        desired_io.seek(0)
+        with open("/path/to/image.png", "wb") as f:
+            f.write(desired_io.read())
+        """
+        nb_images_per_filter = len(max_activations[0][0]["activation"])
+        fig_subplot_nrows = int(np.ceil(np.sqrt(nb_images_per_filter)))  # type: ignore
+        fig_subplot_ncols = fig_subplot_nrows
+
+        all_layer_io = []
+        for layer_id in max_activations.keys():
+            layer_io = []
+            nb_channels = len(max_activations[layer_id])
+            for channel_id in range(nb_channels):
+                size = max_activations[layer_id][channel_id]["input"][0].shape[0]
+                fig = plt.figure(figsize=(size / 5, size / 5))
+                for index in range(len(max_activations[layer_id][channel_id]["input"])):
+                    ax = fig.add_subplot(
+                        fig_subplot_nrows,
+                        fig_subplot_ncols,
+                        index + 1,
+                    )
+                    ax.imshow(
+                        max_activations[layer_id][channel_id]["input"][index], **kwargs
+                    )
+                    ax.get_xaxis().set_visible(False)
+                    ax.get_yaxis().set_visible(False)
+                b = io.BytesIO()
+                plt.savefig(b, format="png")
+                layer_io.append(b)
+            all_layer_io.append(layer_io)
+        return all_layer_io
+
+
+if __name__ == "__main__":
+    import os
+
+    from tensorflow.keras.preprocessing.image import img_to_array, load_img
+
+    # Get model
+    model = tf.keras.models.load_model(
+        "/home/arnaudcapitaine/01_Projets/2021/demonstrator_image/data/model_cnn_v13"
+    )
+
+    # Get img_dataset
+    mypath = "/home/arnaudcapitaine/01_Projets/2022/readml/data/images/"
+    onlyfiles = [
+        f for f in os.listdir(mypath) if os.path.isfile(os.path.join(mypath, f))
+    ]
+    batch = []
+    for file in onlyfiles:
+        image = load_img(mypath + file, grayscale=True, target_size=(200, 200))
+        img_tensor = img_to_array(image)
+        batch.append(np.expand_dims(img_tensor, 0))
+    batch = np.concatenate(batch)
+    img_dataset = tf.data.Dataset.from_tensor_slices(batch)
+    img_dataset = img_dataset.batch(3)
+
+    # test
+    max_activation = MaxActivation(model)
+    filter_max_activations = max_activation.get_filter_max_activations(img_dataset)
+    all_layer_io = max_activation.get_filter_max_activations_visualization(
+        filter_max_activations, cmap="gray"
+    )
+    desired_io = all_layer_io[3][0]
+    desired_io.seek(0)
+    with open("/home/arnaudcapitaine/Bureau/image.png", "wb") as f:
+        f.write(desired_io.read())

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -10,7 +10,7 @@ scikit-learn
 shap
 colorlog
 beautifulsoup4
-tensorflow
+tensorflow==2.4.0
 matplotlib
 opencv-python
 imutils

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -42,6 +42,8 @@ defusedxml==0.6.0
     # via nbconvert
 entrypoints==0.3
     # via nbconvert
+flatbuffers==1.12
+    # via tensorflow
 gast==0.3.3
     # via tensorflow
 google-auth-oauthlib==0.4.2
@@ -52,7 +54,7 @@ google-auth==1.24.0
     #   tensorboard
 google-pasta==0.2.0
     # via tensorflow
-grpcio==1.35.0
+grpcio==1.32.0
     # via
     #   tensorboard
     #   tensorflow
@@ -124,7 +126,7 @@ nbformat==5.0.7
     #   notebook
 notebook==6.1.3
     # via widgetsnbextension
-numpy==1.19.1
+numpy==1.19.5
     # via
     #   -r requirements/requirements.in
     #   h5py
@@ -226,7 +228,6 @@ scipy==1.4.1
     # via
     #   scikit-learn
     #   shap
-    #   tensorflow
 send2trash==1.5.0
     # via notebook
 shap==0.35.0
@@ -250,18 +251,19 @@ six==1.15.0
     #   pyrsistent
     #   python-dateutil
     #   retrying
-    #   tensorboard
     #   tensorflow
     #   traitlets
 soupsieve==2.1
     # via beautifulsoup4
+tensorboard-data-server==0.6.1
+    # via tensorboard
 tensorboard-plugin-wit==1.8.0
     # via tensorboard
-tensorboard==2.2.2
+tensorboard==2.8.0
     # via tensorflow
-tensorflow-estimator==2.2.0
+tensorflow-estimator==2.4.0
     # via tensorflow
-tensorflow==2.2.0
+tensorflow==2.4.0
     # via -r requirements/requirements.in
 termcolor==1.1.0
     # via tensorflow
@@ -289,6 +291,8 @@ traitlets==4.3.3
     #   nbconvert
     #   nbformat
     #   notebook
+typing-extensions==3.7.4.3
+    # via tensorflow
 urllib3==1.26.3
     # via requests
 wcwidth==0.2.5

--- a/tests/test_explainers/test_dl/test_max_activations.py
+++ b/tests/test_explainers/test_dl/test_max_activations.py
@@ -124,9 +124,9 @@ def test_create_input_image_maximizing_activations():
     )
     expected_output = np.array(
         [
-            [[254.01408], [1.0255346], [185.34874]],
-            [[253.97502], [253.97734], [191.30005]],
-            [[90.436195], [62.927162], [174.11365]],
+            [[254.01408], [253.98782], [1.0375116]],
+            [[104.22838], [253.97734], [1.0404677]],
+            [[90.436195], [253.95912], [253.99373]],
         ]
     )
     assert np.testing.assert_array_almost_equal(input_value, expected_output, decimal=5)

--- a/tests/test_explainers/test_dl/test_max_activations.py
+++ b/tests/test_explainers/test_dl/test_max_activations.py
@@ -67,7 +67,7 @@ def test_get_filter_max_activations():
     assert len(filter_max_activations) == 2
     assert len(filter_max_activations[0]) == NB_CHANNEL_CONV2D[0]
     assert len(filter_max_activations[1]) == NB_CHANNEL_CONV2D[1]
-    assert filter_max_activations[0][1]["activation"][1] == 255 * 5
+    assert filter_max_activations[0][1]["activation"][1] == np.sum(INPUT_IMAGE_3x3)
     assert (
         filter_max_activations[0][1]["input"][1].numpy()[:, :, 0] == INPUT_IMAGE_3x3
     ).all()

--- a/tests/test_explainers/test_dl/test_max_activations.py
+++ b/tests/test_explainers/test_dl/test_max_activations.py
@@ -56,7 +56,7 @@ def get_image_dataset(nb_channel):
     return img_dataset
 
 
-def test_get_filter_max_activations():
+def test_get_filter_max_activations_from_image_dataset():
     nb_channel = 1
     model = get_model(nb_channel)
     img_dataset = get_image_dataset(nb_channel)
@@ -65,15 +65,18 @@ def test_get_filter_max_activations():
         max_activation.get_filter_max_activations_from_image_dataset(img_dataset)
     )
     assert len(filter_max_activations) == 2
-    assert len(filter_max_activations[0]) == NB_CHANNEL_CONV2D[0]
-    assert len(filter_max_activations[1]) == NB_CHANNEL_CONV2D[1]
-    assert filter_max_activations[0][1]["activation"][1] == np.sum(INPUT_IMAGE_3x3)
+    assert len(filter_max_activations["conv2d"]) == NB_CHANNEL_CONV2D[0]
+    assert len(filter_max_activations["conv2d_1"]) == NB_CHANNEL_CONV2D[1]
+    assert filter_max_activations["conv2d"][1]["activation"][1] == np.sum(
+        INPUT_IMAGE_3x3
+    )
     assert (
-        filter_max_activations[0][1]["input"][1].numpy()[:, :, 0] == INPUT_IMAGE_3x3
+        filter_max_activations["conv2d"][1]["input"][1].numpy()[:, :, 0]
+        == INPUT_IMAGE_3x3
     ).all()
-    assert filter_max_activations[1][0]["activation"][2] == 719
+    assert filter_max_activations["conv2d_1"][0]["activation"][2] == 719
     assert (
-        filter_max_activations[1][0]["input"][2].numpy()[:, :, 0]
+        filter_max_activations["conv2d_1"][0]["input"][2].numpy()[:, :, 0]
         == np.array(
             [
                 [9, 188, 91, 111, 163, 83, 76, 18],
@@ -95,8 +98,10 @@ def test_get_filter_max_activations():
     filter_max_activations = (
         max_activation.get_filter_max_activations_from_image_dataset(img_dataset)
     )
-    assert filter_max_activations[0][0]["input"][0].shape == np.array([3, 3, 3])
+    assert filter_max_activations["conv2d_2"][0]["input"][0].shape == np.array(
+        [3, 3, 3]
+    )
 
 
 if __name__ == "__main__":
-    test_get_filter_max_activations()
+    test_get_filter_max_activations_from_image_dataset()

--- a/tests/test_explainers/test_dl/test_max_activations.py
+++ b/tests/test_explainers/test_dl/test_max_activations.py
@@ -61,7 +61,9 @@ def test_get_filter_max_activations():
     model = get_model(nb_channel)
     img_dataset = get_image_dataset(nb_channel)
     max_activation = MaxActivation(model)
-    filter_max_activations = max_activation.get_filter_max_activations(img_dataset)
+    filter_max_activations = (
+        max_activation.get_filter_max_activations_from_image_dataset(img_dataset)
+    )
     assert len(filter_max_activations) == 2
     assert len(filter_max_activations[0]) == NB_CHANNEL_CONV2D[0]
     assert len(filter_max_activations[1]) == NB_CHANNEL_CONV2D[1]
@@ -90,7 +92,9 @@ def test_get_filter_max_activations():
     model = get_model(nb_channel)
     img_dataset = get_image_dataset(nb_channel)
     max_activation = MaxActivation(model)
-    filter_max_activations = max_activation.get_filter_max_activations(img_dataset)
+    filter_max_activations = (
+        max_activation.get_filter_max_activations_from_image_dataset(img_dataset)
+    )
     assert filter_max_activations[0][0]["input"][0].shape == np.array([3, 3, 3])
 
 

--- a/tests/test_explainers/test_dl/test_max_activations.py
+++ b/tests/test_explainers/test_dl/test_max_activations.py
@@ -1,0 +1,98 @@
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.layers import Conv2D, Dense, Flatten, Input, MaxPooling2D
+from tensorflow.keras.models import Sequential
+
+from readml.explainers.dl.max_activations import MaxActivation
+
+HEIGHT = 200
+WIDTH = 200
+NB_CHANNEL_CONV2D = [2, 4]
+INPUT_IMAGE_3x3 = np.array([[255, 255, 0], [0, 255, 0], [0, 255, 255]])
+
+
+def get_model(nb_channel):
+    model = Sequential(
+        [
+            Input(shape=(HEIGHT, WIDTH, nb_channel)),
+            Conv2D(
+                NB_CHANNEL_CONV2D[0],
+                kernel_size=(3, 3),
+                activation="relu",
+                kernel_initializer=tf.keras.initializers.GlorotNormal(seed=0),
+                padding="same",
+            ),
+            MaxPooling2D(pool_size=(2, 2)),
+            Conv2D(
+                NB_CHANNEL_CONV2D[1],
+                kernel_size=(3, 3),
+                activation="relu",
+                kernel_initializer=tf.keras.initializers.GlorotNormal(seed=0),
+                padding="valid",
+            ),
+            MaxPooling2D(pool_size=(2, 2)),
+            Flatten(),
+            Dense(
+                1,
+                activation="sigmoid",
+                kernel_initializer=tf.keras.initializers.GlorotNormal(seed=0),
+            ),
+        ]
+    )
+    model.weights[0][:, :, 0, 1].assign(np.array([[1, 1, -1], [0, 1, -1], [0, 1, 1]]))
+    model.weights[2][:, :, 0, 0].assign(np.zeros((3, 3)))
+    model.weights[2][:, :, 1, 0].assign(
+        np.array([[-1, -1, -1], [-1, 4, -1], [-1, -1, -1]])
+    )
+    return model
+
+
+def get_image_dataset(nb_channel):
+    np.random.seed(0)
+    image_dataset = np.random.randint(0, 255, size=(10, HEIGHT, WIDTH, nb_channel))
+    image_dataset[0, 5:8, 10:13, 0] = INPUT_IMAGE_3x3
+    img_dataset = tf.data.Dataset.from_tensor_slices(image_dataset)
+    img_dataset = img_dataset.batch(3)
+    return img_dataset
+
+
+def test_get_filter_max_activations():
+    nb_channel = 1
+    model = get_model(nb_channel)
+    img_dataset = get_image_dataset(nb_channel)
+    max_activation = MaxActivation(model)
+    filter_max_activations = max_activation.get_filter_max_activations(img_dataset)
+    assert len(filter_max_activations) == 2
+    assert len(filter_max_activations[0]) == NB_CHANNEL_CONV2D[0]
+    assert len(filter_max_activations[1]) == NB_CHANNEL_CONV2D[1]
+    assert filter_max_activations[0][1]["activation"][1] == 255 * 5
+    assert (
+        filter_max_activations[0][1]["input"][1].numpy()[:, :, 0] == INPUT_IMAGE_3x3
+    ).all()
+    assert filter_max_activations[1][0]["activation"][2] == 719
+    assert (
+        filter_max_activations[1][0]["input"][2].numpy()[:, :, 0]
+        == np.array(
+            [
+                [9, 188, 91, 111, 163, 83, 76, 18],
+                [238, 165, 171, 211, 88, 70, 148, 134],
+                [211, 45, 54, 255, 255, 0, 134, 219],
+                [168, 150, 30, 0, 255, 0, 106, 74],
+                [135, 29, 78, 0, 255, 255, 16, 60],
+                [10, 145, 131, 231, 73, 29, 195, 199],
+                [42, 202, 37, 106, 40, 111, 27, 132],
+                [242, 178, 86, 181, 10, 43, 187, 158],
+            ]
+        )
+    ).all()
+
+    nb_channel = 3
+    model = get_model(nb_channel)
+    img_dataset = get_image_dataset(nb_channel)
+    max_activation = MaxActivation(model)
+    filter_max_activations = max_activation.get_filter_max_activations(img_dataset)
+    assert filter_max_activations[0][0]["input"][0].shape == np.array([3, 3, 3])
+
+
+if __name__ == "__main__":
+    test_get_filter_max_activations()

--- a/tests/test_explainers/test_dl/test_max_activations.py
+++ b/tests/test_explainers/test_dl/test_max_activations.py
@@ -77,9 +77,9 @@ def test_get_filter_max_activations_from_image_dataset():
         == INPUT_IMAGE_3x3
     ).all()
     assert filter_max_activations["conv2d_1"][0]["activation"][2] == 719
-    assert (
-        filter_max_activations["conv2d_1"][0]["input"][2].numpy()[:, :, 0]
-        == np.array(
+    np.testing.assert_array_equal(
+        filter_max_activations["conv2d_1"][0]["input"][2].numpy()[:, :, 0],
+        np.array(
             [
                 [9, 188, 91, 111, 163, 83, 76, 18],
                 [238, 165, 171, 211, 88, 70, 148, 134],
@@ -90,8 +90,8 @@ def test_get_filter_max_activations_from_image_dataset():
                 [42, 202, 37, 106, 40, 111, 27, 132],
                 [242, 178, 86, 181, 10, 43, 187, 158],
             ]
-        )
-    ).all()
+        ),
+    )
 
     nb_channel = 3
     model = get_model(nb_channel)
@@ -129,7 +129,8 @@ def test_create_input_image_maximizing_activations():
             [[90.436195], [253.95912], [253.99373]],
         ]
     )
-    assert np.testing.assert_array_almost_equal(input_value, expected_output, decimal=5)
+    np.testing.assert_array_almost_equal(input_value, expected_output, decimal=5)
+    assert np.all(np.diff(activation_history) > 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implement max activation computation for the global explainability of the CNN models. From a given trained CNN model and a given image dataset, the input image parts that maximize the activations of the filters of the CNN are retrieved. 